### PR TITLE
refactor the url utils

### DIFF
--- a/safe_rcm/fs_utils.py
+++ b/safe_rcm/fs_utils.py
@@ -3,10 +3,10 @@ from urllib.parse import urlsplit, urlunsplit
 
 
 def split_url(url):
-    if url.count("::") > 1:
-        # TODO: unlike urllib.parse, `fsspec` allows nested urls
+    if url.count("::") != 0:
+        # TODO: unlike urllib.parse, `fsspec` allows chaining urls
         #       so we need to find a way to support that, as well
-        raise ValueError("don't know how to deal with nested urls")
+        raise ValueError("don't know how to deal with url chains")
 
     return urlsplit(url)
 

--- a/safe_rcm/fs_utils.py
+++ b/safe_rcm/fs_utils.py
@@ -1,5 +1,6 @@
 import posixpath
-from urllib.parse import urljoin, urlsplit, urlunsplit
+from urllib.parse import urljoin  # noqa: F401
+from urllib.parse import urlsplit, urlunsplit
 
 
 def split_url(url):
@@ -9,24 +10,6 @@ def split_url(url):
         raise ValueError("don't know how to deal with url chains")
 
     return urlsplit(url)
-
-
-def normalize_url_path(url):
-    """convert the url's path component to absolute"""
-    split = split_url(url)
-    normalized = posixpath.normpath(split.path)
-
-    return urlunsplit(split._replace(path=normalized))
-
-
-def dirname(url):
-    split = split_url(url)
-    new_path = posixpath.dirname(split.path)
-    return urlunsplit(split._replace(path=new_path))
-
-
-def join_path(url, path):
-    return urljoin(url, path)
 
 
 def split(url):

--- a/safe_rcm/fs_utils.py
+++ b/safe_rcm/fs_utils.py
@@ -13,12 +13,7 @@ def split_url(url):
 
 def normalize_url_path(url):
     """convert the url's path component to absolute"""
-    if url.count("::") > 1:
-        # TODO: unlike urllib.parse, `fsspec` allows nested urls
-        #       so we need to find a way to support that, as well
-        raise ValueError("don't know how to deal with nested urls")
-
-    split = urlsplit(url)
+    split = split_url(url)
     normalized = posixpath.normpath(split.path)
 
     return urlunsplit(split._replace(path=normalized))

--- a/safe_rcm/fs_utils.py
+++ b/safe_rcm/fs_utils.py
@@ -1,5 +1,5 @@
 import posixpath
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import urljoin, urlsplit, urlunsplit
 
 
 def split_url(url):
@@ -26,15 +26,7 @@ def dirname(url):
 
 
 def join_path(url, path):
-    split = split_url(url)
-    if posixpath.isabs(path):
-        joined_path = path
-    else:
-        joined_path = posixpath.normpath(posixpath.join(split.path, path))
-
-    joined = split._replace(path=joined_path)
-
-    return urlunsplit(joined)
+    return urljoin(url, path)
 
 
 def split(url):

--- a/safe_rcm/tests/test_fs_utils.py
+++ b/safe_rcm/tests/test_fs_utils.py
@@ -1,0 +1,20 @@
+import pytest
+
+from safe_rcm import fs_utils
+
+# TODO: find properties that allow us to use `hypothesis`
+
+
+@pytest.mark.parametrize(
+    ["url", "expected"],
+    (
+        pytest.param("file:///a/b.xml", ("file:///a", "b.xml"), id="local"),
+        pytest.param(
+            "http://host:9754/a/b.xml", ("http://host:9754/a", "b.xml"), id="http"
+        ),
+    ),
+)
+def test_split(url, expected):
+    actual = fs_utils.split(url)
+
+    assert actual == expected

--- a/safe_rcm/xml.py
+++ b/safe_rcm/xml.py
@@ -41,8 +41,7 @@ def read_xml(fs, url):
     schema_location = tree.xpath("./@xsi:schemaLocation", namespaces=namespaces)[0]
     _, schema_path = schema_location.split(" ")
 
-    root = fs_utils.dirname(url)
-    schema_url = fs_utils.join_path(root, schema_path)
+    schema_url = fs_utils.urljoin(url, schema_path)
     schema_root, schema_name = fs_utils.split(schema_url)
 
     schema = open_schema(fs, schema_root, schema_name)


### PR DESCRIPTION
Since I just found out about `urllib.parse.urljoin`, it seems we don't need most of the code in `fs_utils`. I guess we could replace `split` with `urljoin` somehow, but I don't think it makes too much of a difference.