### PR TITLE
extract the raster attributes

### DIFF
--- a/safe_rcm/product/predicates.py
+++ b/safe_rcm/product/predicates.py
@@ -5,14 +5,23 @@ def is_scalar(x):
     return not toolz.itertoolz.isiterable(x) or isinstance(x, (str, bytes))
 
 
-def is_complex(obj):
-    if not isinstance(obj, list) or len(obj) != 2:
+def is_composite_value(obj):
+    if not isinstance(obj, list) or len(obj) not in [1, 2]:
         return False
 
     if any(list(el) != ["@dataStream", "$"] for el in obj):
         return False
 
-    return [el["@dataStream"].lower() for el in obj] == ["real", "imaginary"]
+    data_stream_values = [el["@dataStream"].lower() for el in obj]
+    return data_stream_values in (["real", "imaginary"], ["magnitude"])
+
+
+def is_complex(obj):
+    return is_composite_value(obj) and len(obj) == 2
+
+
+def is_magnitude(obj):
+    return is_composite_value(obj) and len(obj) == 1
 
 
 def is_array(obj):

--- a/safe_rcm/product/reader.py
+++ b/safe_rcm/product/reader.py
@@ -47,6 +47,10 @@ def read_product(fs, product_url):
             "path": "/imageReferenceAttributes",
             "f": converters.extract_metadata,
         },
+        "/imageReferenceAttributes/rasterAttributes": {
+            "path": "/imageReferenceAttributes/rasterAttributes",
+            "f": transformers.extract_dataset,
+        },
         "/imageReferenceAttributes/geographicInformation/ellipsoidParameters": {
             "path": "/imageReferenceAttributes/geographicInformation/ellipsoidParameters",
             "f": curry(transformers.extract_dataset)(dims="params"),


### PR DESCRIPTION
This completes the extraction of the image reference attributes from `product.xml`, all other parts need to be added when postprocessing the datatree by looking at the `incidenceAngleFileName` attribute and the `lookupTableFileName` and `noiseLevelFileName` variables.