### PR TITLE
ingest the source attributes

### DIFF
--- a/safe_rcm/product/dicttoolz.py
+++ b/safe_rcm/product/dicttoolz.py
@@ -25,3 +25,7 @@ def valsplit(predicate, d):
 def keysplit(predicate, d):
     wrapper = lambda item: predicate(item[0])
     return itemsplit(wrapper, d)
+
+
+def first_values(d):
+    return toolz.itertoolz.first(d.values())

--- a/safe_rcm/product/predicates.py
+++ b/safe_rcm/product/predicates.py
@@ -73,10 +73,13 @@ def is_nested(obj):
     if not isinstance(elem, dict):
         return False
 
-    return all(
-        is_scalar(value) or (isinstance(value, list) and len(value) == 1)
-        for value in elem.values()
-    )
+    if all(
+        is_scalar(v) or (is_array(v) and len(v) == 1) or is_scalar_variable(v)
+        for v in elem.values()
+    ):
+        return True
+
+    return False
 
 
 def is_nested_array(obj):

--- a/safe_rcm/product/predicates.py
+++ b/safe_rcm/product/predicates.py
@@ -54,6 +54,16 @@ def is_array(obj):
     return False
 
 
+def is_scalar_variable(obj):
+    if not isinstance(obj, dict):
+        return False
+
+    if not all(is_scalar(v) for v in obj.values()):
+        return False
+
+    return all(k == "$" or k.startswith("@") for k in obj)
+
+
 def is_nested(obj):
     """nested means: list of dict, but all dict values are scalar or 1-valued"""
     if not isinstance(obj, list) or len(obj) == 0:

--- a/safe_rcm/product/predicates.py
+++ b/safe_rcm/product/predicates.py
@@ -51,3 +51,22 @@ def is_array(obj):
             return True
 
     return False
+
+
+def is_nested(obj):
+    """nested means: list of dict, but all dict values are scalar or 1-valued"""
+    if not isinstance(obj, list) or len(obj) == 0:
+        return False
+
+    elem = obj[0]
+    if not isinstance(elem, dict):
+        return False
+
+    return all(
+        is_scalar(value) or (isinstance(value, list) and len(value) == 1)
+        for value in elem.values()
+    )
+
+
+def is_nested_array(obj):
+    return is_nested(obj) and "$" in obj[0]

--- a/safe_rcm/product/predicates.py
+++ b/safe_rcm/product/predicates.py
@@ -1,3 +1,4 @@
+import numpy as np
 import toolz
 
 
@@ -70,3 +71,8 @@ def is_nested(obj):
 
 def is_nested_array(obj):
     return is_nested(obj) and "$" in obj[0]
+
+
+def is_attr(column):
+    """an attribute is a index if it has multiple unique values"""
+    return np.unique(column).size == 1

--- a/safe_rcm/product/predicates.py
+++ b/safe_rcm/product/predicates.py
@@ -73,6 +73,10 @@ def is_nested_array(obj):
     return is_nested(obj) and "$" in obj[0]
 
 
+def is_nested_dataset(obj):
+    return is_nested(obj) and "$" not in obj[0]
+
+
 def is_attr(column):
     """an attribute is a index if it has multiple unique values"""
     return np.unique(column).size == 1

--- a/safe_rcm/product/reader.py
+++ b/safe_rcm/product/reader.py
@@ -57,12 +57,8 @@ def read_product(fs, product_url):
         },
         "/sourceAttributes/orbitAndAttitude/orbitInformation": {
             "path": "/sourceAttributes/orbitAndAttitude/orbitInformation",
-            "f": transformers.extract_dataset,
-        },
-        "/sourceAttributes/orbitAndAttitude/orbitInformation/stateVector": {
-            "path": "/sourceAttributes/orbitAndAttitude/orbitInformation/stateVector",
             "f": compose_left(
-                curry(transformers.extract_nested_dataset)(dims="timeStamp"),
+                curry(transformers.extract_dataset)(dims="timeStamp"),
                 lambda ds: ds.assign_coords(
                     {"timeStamp": ds["timeStamp"].astype("datetime64")}
                 ),
@@ -70,12 +66,8 @@ def read_product(fs, product_url):
         },
         "/sourceAttributes/orbitAndAttitude/attitudeInformation": {
             "path": "/sourceAttributes/orbitAndAttitude/attitudeInformation",
-            "f": transformers.extract_dataset,
-        },
-        "/sourceAttributes/orbitAndAttitude/attitudeInformation/attitudeAngles": {
-            "path": "/sourceAttributes/orbitAndAttitude/attitudeInformation/attitudeAngles",
             "f": compose_left(
-                curry(transformers.extract_nested_dataset)(dims="timeStamp"),
+                curry(transformers.extract_dataset)(dims="timeStamp"),
                 lambda ds: ds.assign_coords(
                     {"timeStamp": ds["timeStamp"].astype("datetime64")}
                 ),

--- a/safe_rcm/product/reader.py
+++ b/safe_rcm/product/reader.py
@@ -43,6 +43,44 @@ def read_product(fs, product_url):
             "path": "/",
             "f": curry(converters.extract_metadata)(collapse=["securityAttributes"]),
         },
+        "/sourceAttributes": {
+            "path": "/sourceAttributes",
+            "f": converters.extract_metadata,
+        },
+        "/sourceAttributes/radarParameters": {
+            "path": "/sourceAttributes/radarParameters",
+            "f": transformers.extract_dataset,
+        },
+        "/sourceAttributes/radarParameters/prfInformation": {
+            "path": "/sourceAttributes/radarParameters/prfInformation",
+            "f": transformers.extract_nested_dataset,
+        },
+        "/sourceAttributes/orbitAndAttitude/orbitInformation": {
+            "path": "/sourceAttributes/orbitAndAttitude/orbitInformation",
+            "f": transformers.extract_dataset,
+        },
+        "/sourceAttributes/orbitAndAttitude/orbitInformation/stateVector": {
+            "path": "/sourceAttributes/orbitAndAttitude/orbitInformation/stateVector",
+            "f": compose_left(
+                curry(transformers.extract_nested_dataset)(dims="timeStamp"),
+                lambda ds: ds.assign_coords(
+                    {"timeStamp": ds["timeStamp"].astype("datetime64")}
+                ),
+            ),
+        },
+        "/sourceAttributes/orbitAndAttitude/attitudeInformation": {
+            "path": "/sourceAttributes/orbitAndAttitude/attitudeInformation",
+            "f": transformers.extract_dataset,
+        },
+        "/sourceAttributes/orbitAndAttitude/attitudeInformation/attitudeAngles": {
+            "path": "/sourceAttributes/orbitAndAttitude/attitudeInformation/attitudeAngles",
+            "f": compose_left(
+                curry(transformers.extract_nested_dataset)(dims="timeStamp"),
+                lambda ds: ds.assign_coords(
+                    {"timeStamp": ds["timeStamp"].astype("datetime64")}
+                ),
+            ),
+        },
         "/imageReferenceAttributes": {
             "path": "/imageReferenceAttributes",
             "f": converters.extract_metadata,

--- a/safe_rcm/product/transformers.py
+++ b/safe_rcm/product/transformers.py
@@ -107,15 +107,16 @@ def unstack(obj, dim="stacked"):
     return obj.set_index({dim: stacked_coords}).unstack(dim)
 
 
+def to_variable_tuple(name, value, dims):
+    if name in dims:
+        dims_ = [name]
+    else:
+        dims_ = dims
+
+    return (dims_, value)
+
+
 def extract_nested_array(obj):
-    def to_variable_tuple(name, value, dims):
-        if name in dims:
-            dims_ = [name]
-        else:
-            dims_ = dims
-
-        return (dims_, value)
-
     columns = toolz.dicttoolz.merge_with(list, *obj)
 
     attributes, data = keysplit(flip(str.startswith, "@"), columns)

--- a/safe_rcm/product/transformers.py
+++ b/safe_rcm/product/transformers.py
@@ -86,7 +86,7 @@ def extract_dataset(obj, dims=None):
     return xr.Dataset(data_vars=data_vars, attrs=attrs)
 
 
-def extract_nested_variable(obj, dims):
+def extract_nested_variable(obj, dims=None):
     if is_array(obj):
         return xr.Variable(dims, obj)
 

--- a/safe_rcm/product/transformers.py
+++ b/safe_rcm/product/transformers.py
@@ -10,6 +10,7 @@ from .predicates import (
     is_attr,
     is_composite_value,
     is_nested_array,
+    is_nested_dataset,
     is_scalar,
 )
 
@@ -74,10 +75,13 @@ def extract_entry(name, obj, dims=None):
 
 def extract_dataset(obj, dims=None):
     attrs, variables = valsplit(is_scalar, obj)
+    filtered_variables = toolz.dicttoolz.valfilter(
+        lambda x: not is_nested_dataset(x), variables
+    )
 
     vars_ = toolz.dicttoolz.itemmap(
         lambda item: (item[0], extract_entry(*item, dims=dims)),
-        variables,
+        filtered_variables,
     )
     return xr.Dataset(data_vars=vars_, attrs=attrs)
 

--- a/safe_rcm/product/transformers.py
+++ b/safe_rcm/product/transformers.py
@@ -4,7 +4,7 @@ import toolz
 import xarray as xr
 from toolz.functoolz import curry, flip
 
-from .dicttoolz import keysplit, valsplit
+from .dicttoolz import first_values, keysplit, valsplit
 from .predicates import (
     is_array,
     is_attr,
@@ -75,6 +75,11 @@ def extract_entry(name, obj, dims=None):
 
 def extract_dataset(obj, dims=None):
     attrs, variables = valsplit(is_scalar, obj)
+    if len(variables) == 1 and is_nested_dataset(first_values(variables)):
+        return extract_nested_dataset(first_values(variables), dims=dims).assign_attrs(
+            attrs
+        )
+
     filtered_variables = toolz.dicttoolz.valfilter(
         lambda x: not is_nested_dataset(x), variables
     )

--- a/safe_rcm/product/transformers.py
+++ b/safe_rcm/product/transformers.py
@@ -79,11 +79,11 @@ def extract_dataset(obj, dims=None):
         lambda x: not is_nested_dataset(x), variables
     )
 
-    vars_ = toolz.dicttoolz.itemmap(
+    data_vars = toolz.dicttoolz.itemmap(
         lambda item: (item[0], extract_entry(*item, dims=dims)),
         filtered_variables,
     )
-    return xr.Dataset(data_vars=vars_, attrs=attrs)
+    return xr.Dataset(data_vars=data_vars, attrs=attrs)
 
 
 def extract_nested_variable(obj, dims):

--- a/safe_rcm/product/transformers.py
+++ b/safe_rcm/product/transformers.py
@@ -47,11 +47,27 @@ def extract_variable(obj, dims=()):
     return xr.Variable(dims, values, attrs)
 
 
+def extract_entry(name, obj, dims=None):
+    if dims is None:
+        dims = [name]
+
+    if is_array(obj):
+        # dimension coordinate
+        return extract_array(obj, dims=dims)
+    elif is_composite_value(obj):
+        return extract_composite(obj, dims=dims)
+    elif isinstance(obj, dict):
+        return extract_variable(obj, dims=dims)
+    else:
+        raise ValueError(f"unknown datastructure:\n{obj}")
+
+
 def extract_dataset(obj, dims=()):
     attrs, variables = valsplit(is_scalar, obj)
 
-    vars_ = toolz.dicttoolz.valmap(
-        toolz.functoolz.curry(extract_variable)(dims=dims), variables
+    vars_ = toolz.dicttoolz.itemmap(
+        lambda item: (item[0], extract_entry(*item, dims=dims)),
+        variables,
     )
     return xr.Dataset(data_vars=vars_, attrs=attrs)
 

--- a/safe_rcm/product/transformers.py
+++ b/safe_rcm/product/transformers.py
@@ -18,16 +18,22 @@ def convert_composite(value):
         return "complex", converted["real"] + 1j * converted["imaginary"]
 
 
+def extract_array(obj, dims):
+    # special case for pulses:
+    if dims == "pulses" and len(obj) == 1 and isinstance(obj[0], str):
+        obj = obj[0].split()
+    return xr.Variable(dims, obj)
+
+
+def extract_composite(obj, dims=()):
+    type_, value = convert_composite(obj)
+
+    if is_scalar(value):
+        dims = ()
+    return xr.Variable(dims, value, {"type": type_})
+
+
 def extract_variable(obj, dims=()):
-    if is_array(obj):
-        return xr.Variable(dims, obj)
-    elif is_composite_value(obj):
-        type_, value = convert_composite(obj)
-
-        if is_scalar(value):
-            dims = ()
-        return xr.Variable(dims, value, {"type": type_})
-
     attributes, data = keysplit(lambda k: k.startswith("@"), obj)
     if list(data) != ["$"]:
         raise ValueError("not a variable")

--- a/safe_rcm/product/transformers.py
+++ b/safe_rcm/product/transformers.py
@@ -72,7 +72,7 @@ def extract_entry(name, obj, dims=None):
         raise ValueError(f"unknown datastructure:\n{obj}")
 
 
-def extract_dataset(obj, dims=()):
+def extract_dataset(obj, dims=None):
     attrs, variables = valsplit(is_scalar, obj)
 
     vars_ = toolz.dicttoolz.itemmap(


### PR DESCRIPTION
This reads most of the source attributes from the `product.xml`, with the exception of the `rawDataAttributes` section because that is a bit tricky with its histogram column.

~I'm not really content with the coding right now, as I had to split `orbitInformation` and `attitudeInformation` into two nodes, but I will leave that for further refactoring.~ fixed by improving `extract_dataset`.