### PR TITLE
extract source attributes

### DIFF
--- a/safe_rcm/product/predicates.py
+++ b/safe_rcm/product/predicates.py
@@ -10,7 +10,7 @@ def is_composite_value(obj):
     if not isinstance(obj, list) or len(obj) not in [1, 2]:
         return False
 
-    if any(list(el) != ["@dataStream", "$"] for el in obj):
+    if any(not isinstance(el, dict) or list(el) != ["@dataStream", "$"] for el in obj):
         return False
 
     data_stream_values = [el["@dataStream"].lower() for el in obj]

--- a/safe_rcm/product/reader.py
+++ b/safe_rcm/product/reader.py
@@ -98,6 +98,14 @@ def read_product(fs, product_url):
             "path": "/imageReferenceAttributes/geographicInformation/rationalFunctions",
             "f": curry(transformers.extract_dataset)(dims="coefficients"),
         },
+        "/sceneAttributes": {
+            "path": "/sceneAttributes/imageAttributes",
+            "f": compose_left(
+                toolz.itertoolz.first,  # GRD datasets only have 1
+                curry(toolz.dicttoolz.keyfilter)(lambda x: not x.startswith("@")),
+                transformers.extract_dataset,
+            ),
+        },
     }
 
     converted = toolz.dicttoolz.valmap(

--- a/safe_rcm/product/transformers.py
+++ b/safe_rcm/product/transformers.py
@@ -126,8 +126,9 @@ def extract_nested_array(obj):
 
     attributes, data = keysplit(flip(str.startswith, "@"), columns)
     renamed = toolz.dicttoolz.keymap(flip(str.lstrip, "@"), attributes)
-    preprocessed = toolz.dicttoolz.valmap(np.squeeze, renamed)
-    attrs_, indexes = valsplit(is_attr, preprocessed)
+    preprocessed_attrs = toolz.dicttoolz.valmap(np.squeeze, renamed)
+    attrs_, indexes = valsplit(is_attr, preprocessed_attrs)
+    preprocessed_data = toolz.dicttoolz.valmap(np.squeeze, data)
 
     if len(indexes) == 1:
         dims = list(indexes)
@@ -140,7 +141,7 @@ def extract_nested_array(obj):
     )
 
     arr = xr.DataArray(
-        data=data["$"],
+        data=preprocessed_data["$"],
         attrs=toolz.dicttoolz.valmap(toolz.itertoolz.first, attrs_),
         dims=dims,
         coords=coords,


### PR DESCRIPTION
The scene attributes (which contain links to the actual data files) only have a single entry, which makes it quite a bit easier to extract. For other products, that might not be true, and we have to think about what to do with those once we add support for them.