### PR TITLE
extract the top-level reference attributes

### DIFF
--- a/safe_rcm/product/predicates.py
+++ b/safe_rcm/product/predicates.py
@@ -1,10 +1,10 @@
 import numpy as np
-import toolz
 from toolz.functoolz import compose, juxt
+from toolz.itertoolz import isiterable
 
 
 def is_scalar(x):
-    return not toolz.itertoolz.isiterable(x) or isinstance(x, (str, bytes))
+    return not isiterable(x) or isinstance(x, (str, bytes))
 
 
 def is_composite_value(obj):

--- a/safe_rcm/product/predicates.py
+++ b/safe_rcm/product/predicates.py
@@ -90,6 +90,14 @@ def is_nested_dataset(obj):
     return is_nested(obj) and "$" not in obj[0]
 
 
+def or_(obj, *funcs):
+    return any(toolz.functoolz.juxt(*funcs)(obj))
+
+
+def and_(obj, *funcs):
+    return all(toolz.functoolz.juxt(*funcs)(obj))
+
+
 def is_attr(column):
     """an attribute is a index if it has multiple unique values"""
     return np.unique(column).size == 1

--- a/safe_rcm/product/predicates.py
+++ b/safe_rcm/product/predicates.py
@@ -1,5 +1,6 @@
 import numpy as np
 import toolz
+from toolz.functoolz import compose, juxt
 
 
 def is_scalar(x):
@@ -90,12 +91,12 @@ def is_nested_dataset(obj):
     return is_nested(obj) and "$" not in obj[0]
 
 
-def or_(obj, *funcs):
-    return any(toolz.functoolz.juxt(*funcs)(obj))
+def disjunction(*predicates):
+    return compose(any, juxt(predicates))
 
 
-def and_(obj, *funcs):
-    return all(toolz.functoolz.juxt(*funcs)(obj))
+def conjunction(*predicates):
+    return compose(all, juxt(predicates))
 
 
 def is_attr(column):

--- a/safe_rcm/product/reader.py
+++ b/safe_rcm/product/reader.py
@@ -6,6 +6,7 @@ from toolz.functoolz import compose_left, curry
 from ..xml import read_xml
 from . import converters, transformers
 from .dicttoolz import query
+from .predicates import disjunction, is_nested_array, is_scalar_valued
 
 
 @curry
@@ -75,7 +76,12 @@ def read_product(fs, product_url):
         },
         "/imageReferenceAttributes": {
             "path": "/imageReferenceAttributes",
-            "f": converters.extract_metadata,
+            "f": compose_left(
+                curry(toolz.dicttoolz.valfilter)(
+                    disjunction(is_scalar_valued, is_nested_array)
+                ),
+                transformers.extract_dataset,
+            ),
         },
         "/imageReferenceAttributes/rasterAttributes": {
             "path": "/imageReferenceAttributes/rasterAttributes",


### PR DESCRIPTION
Follow-up to #6

This also extracts the skipped top-level variables (in particular, the names of the calibration files).