### PR TITLE
extract the lookup tables

### DIFF
--- a/safe_rcm/api.py
+++ b/safe_rcm/api.py
@@ -19,6 +19,7 @@ def execute(tree, f, path):
     return f(node)
 
 
+@curry
 def starcall(f, args):
     return f(*args)
 
@@ -64,7 +65,7 @@ def open_rcm(url, *, backend_kwargs=None, **dataset_kwargs):
                     ),
                     lambda obj: obj.coords,
                 ),
-                curry(starcall)(lambda arr, coords: arr.assign_coords(coords)),
+                starcall(lambda arr, coords: arr.assign_coords(coords)),
                 lambda arr: arr.set_index({"stacked": ["sarCalibrationType", "pole"]}),
                 lambda arr: arr.unstack("stacked"),
                 lambda arr: arr.rename("lookup_tables"),


### PR DESCRIPTION
towards #19

This uses the `lookupTableFileName` variable to add the lookup tables to the tree. The implementation is a bit hacky, though, as the stacking / unstacking does not work quite as well as I'd hoped it would.