### PR TITLE
use `cytoolz` whenever possible

### DIFF
--- a/safe_rcm/api.py
+++ b/safe_rcm/api.py
@@ -4,13 +4,18 @@ import posixpath
 import datatree
 import fsspec
 import xarray as xr
-from toolz.dicttoolz import valmap
-from toolz.functoolz import compose_left, curry, juxt
 
 from .calibrations import read_noise_levels
 from .product.reader import read_product
 from .product.transformers import extract_dataset
 from .xml import read_xml
+
+try:
+    from cytoolz.dicttoolz import valmap
+    from cytoolz.functoolz import compose_left, curry, juxt
+except ImportError:
+    from toolz.dicttoolz import valmap
+    from toolz.functoolz import compose_left, curry, juxt
 
 
 @curry

--- a/safe_rcm/calibrations.py
+++ b/safe_rcm/calibrations.py
@@ -3,15 +3,21 @@ import posixpath
 import datatree
 import numpy as np
 import xarray as xr
-from toolz.dicttoolz import itemmap, merge_with, valfilter, valmap
-from toolz.functoolz import compose_left, curry, flip
-from toolz.itertoolz import first
 
 from safe_rcm.product.reader import execute
 
 from .product.dicttoolz import keysplit
 from .product.transformers import extract_dataset
 from .xml import read_xml
+
+try:
+    from cytoolz.dicttoolz import itemmap, merge_with, valfilter, valmap
+    from cytoolz.functoolz import compose_left, curry, flip
+    from cytoolz.itertoolz import first
+except ImportError:
+    from toolz.dicttoolz import itemmap, merge_with, valfilter, valmap
+    from toolz.functoolz import compose_left, curry, flip
+    from toolz.itertoolz import first
 
 
 def move_attrs_to_coords(ds, names):

--- a/safe_rcm/product/dicttoolz.py
+++ b/safe_rcm/product/dicttoolz.py
@@ -1,4 +1,9 @@
-import toolz
+try:
+    from cytoolz.dicttoolz import get_in
+    from cytoolz.itertoolz import first, groupby
+except ImportError:
+    from toolz.dicttoolz import get_in
+    from toolz.itertoolz import first, groupby
 
 
 def query(path, mapping):
@@ -6,11 +11,11 @@ def query(path, mapping):
         return mapping
 
     keys = path.lstrip("/").split("/")
-    return toolz.dicttoolz.get_in(keys, mapping, no_default=True)
+    return get_in(keys, mapping, no_default=True)
 
 
 def itemsplit(predicate, d):
-    groups = toolz.itertoolz.groupby(predicate, d.items())
+    groups = groupby(predicate, d.items())
     first = dict(groups.get(True, ()))
     second = dict(groups.get(False, ()))
 
@@ -28,4 +33,4 @@ def keysplit(predicate, d):
 
 
 def first_values(d):
-    return toolz.itertoolz.first(d.values())
+    return first(d.values())

--- a/safe_rcm/product/predicates.py
+++ b/safe_rcm/product/predicates.py
@@ -1,6 +1,11 @@
 import numpy as np
-from toolz.functoolz import compose, juxt
-from toolz.itertoolz import isiterable
+
+try:
+    from cytoolz.functoolz import compose, juxt
+    from cytoolz.itertoolz import isiterable
+except ImportError:
+    from toolz.functoolz import compose, juxt
+    from toolz.itertoolz import isiterable
 
 
 def disjunction(*predicates):

--- a/safe_rcm/product/utils.py
+++ b/safe_rcm/product/utils.py
@@ -1,10 +1,13 @@
-import toolz
+try:
+    from cytoolz.functoolz import flip, pipe
+    from cytoolz.itertoolz import groupby
+except ImportError:
+    from toolz.functoolz import flip, pipe
+    from toolz.itertoolz import groupby
 
 
 def split_marked(mapping, marker="@"):
-    groups = toolz.itertoolz.groupby(
-        lambda item: item[0].startswith(marker), mapping.items()
-    )
+    groups = groupby(lambda item: item[0].startswith(marker), mapping.items())
 
     attrs = {key.lstrip(marker): value for key, value in groups.get(True, {})}
     data = {key: value for key, value in groups.get(False, {})}
@@ -27,5 +30,5 @@ def strip_namespaces(name, namespaces):
     trimmed : str
         The string without prefix and without leading colon.
     """
-    funcs = [toolz.functoolz.flip(str.removeprefix, ns) for ns in namespaces]
-    return toolz.functoolz.pipe(name, *funcs).lstrip(":")
+    funcs = [flip(str.removeprefix, ns) for ns in namespaces]
+    return pipe(name, *funcs).lstrip(":")

--- a/safe_rcm/xml.py
+++ b/safe_rcm/xml.py
@@ -1,8 +1,12 @@
 import posixpath
 
-import toolz
 import xmlschema
 from lxml import etree
+
+try:
+    from cytoolz.dicttoolz import keymap
+except ImportError:
+    from toolz.dicttoolz import keymap
 
 
 def open_schema(mapper, root, name, *, glob="*.xsd"):
@@ -39,9 +43,7 @@ def read_xml(mapper, path):
     raw_data = mapper[path]
     tree = etree.fromstring(raw_data)
 
-    namespaces = toolz.dicttoolz.keymap(
-        lambda x: x if x is not None else "rcm", tree.nsmap
-    )
+    namespaces = keymap(lambda x: x if x is not None else "rcm", tree.nsmap)
     schema_location = tree.xpath("./@xsi:schemaLocation", namespaces=namespaces)[0]
     _, schema_path_ = schema_location.split(" ")
 


### PR DESCRIPTION
Not sure if the difference is noticeable (it was not during my test), but in general `cytoolz` should be faster than `toolz` while still providing the same functionality. The only thing that had to change was the imports, so this is a pretty cheap change.