### PR TITLE
expose `open_rcm` as public API

### DIFF
--- a/safe_rcm/__init__.py
+++ b/safe_rcm/__init__.py
@@ -1,5 +1,7 @@
 from importlib.metadata import version
 
+from .api import open_rcm  # noqa: F401
+
 try:
     __version__ = version("safe_rcm")
 except Exception:


### PR DESCRIPTION
Still no documentation, but the readme should be enough for now.