### PR TITLE
use a deque to extract the linked schemas

### DIFF
--- a/safe_rcm/xml.py
+++ b/safe_rcm/xml.py
@@ -1,6 +1,7 @@
 import io
 import posixpath
 import re
+from collections import deque
 
 import xmlschema
 from lxml import etree
@@ -9,12 +10,40 @@ from tlz.dicttoolz import keymap
 include_re = re.compile(r'\s*<xsd:include schemaLocation="(?P<location>[^"/]+)"\s?/>')
 
 
-def remove_includes(f):
-    text = f.read().decode()
+def remove_includes(text):
     return io.StringIO(include_re.sub("", text))
 
 
-def open_schema(mapper, root, name, *, glob="*.xsd"):
+def extract_includes(text):
+    return include_re.findall(text)
+
+
+def normalize(root, path):
+    if posixpath.isabs(path) or posixpath.dirname(path):
+        return path
+
+    return posixpath.join(root, path)
+
+
+def schema_paths(mapper, root_schema):
+    unvisited = deque([root_schema])
+    visited = []
+    while unvisited:
+        path = unvisited.popleft()
+        visited.append(path)
+
+        text = mapper[path].decode()
+        includes = extract_includes(text)
+
+        current_root = posixpath.dirname(path)
+        normalized = [normalize(current_root, p) for p in includes]
+
+        unvisited.extend([p for p in normalized if p not in visited])
+
+    return visited
+
+
+def open_schema(mapper, schema):
     """fsspec-compatible way to open remote schema files
 
     Parameters
@@ -33,13 +62,9 @@ def open_schema(mapper, root, name, *, glob="*.xsd"):
     xmlschema.XMLSchema
         The opened schema object
     """
-    schema_root = mapper._key_to_str(root)
-    fs = mapper.fs
+    paths = schema_paths(mapper, schema)
+    preprocessed = [remove_includes(mapper[p].decode()) for p in paths]
 
-    urls = sorted(
-        fs.glob(f"{schema_root}/{glob}"), key=lambda u: u.endswith(name), reverse=True
-    )
-    preprocessed = [remove_includes(fs.open(u)) for u in urls]
     return xmlschema.XMLSchema(preprocessed)
 
 
@@ -54,9 +79,7 @@ def read_xml(mapper, path):
     schema_path = posixpath.normpath(
         posixpath.join(posixpath.dirname(path), schema_path_)
     )
-    schema_root, schema_name = posixpath.split(schema_path)
-
-    schema = open_schema(mapper, schema_root, schema_name)
+    schema = open_schema(mapper, schema_path)
 
     decoded = schema.decode(tree)
 


### PR DESCRIPTION
Instead of reading *all* schemas with the first being the root schema, follow the includes in the schema to recursively get the paths of the actually linked schemas.

In addition to successfully decoding the manifest, this allows us to reduce the open time by a factor of 2 (not sure why, though).