### PR TITLE
use the manifest to provide nicer error messages

### DIFF
--- a/safe_rcm/api.py
+++ b/safe_rcm/api.py
@@ -39,7 +39,12 @@ def open_rcm(url, *, backend_kwargs=None, **dataset_kwargs):
     storage_options = backend_kwargs.get("storage_options", {})
     mapper = fsspec.get_mapper(url, **storage_options)
 
-    declared_files = read_manifest(mapper, "manifest.safe")
+    try:
+        declared_files = read_manifest(mapper, "manifest.safe")
+    except (FileNotFoundError, KeyError):
+        raise ValueError(
+            "cannot find the `manifest.safe` file. Are you sure this is a SAFE dataset?"
+        )
 
     missing_files = [
         path for path in declared_files if not mapper.fs.exists(f"{url}/{path}")

--- a/safe_rcm/api.py
+++ b/safe_rcm/api.py
@@ -8,10 +8,16 @@ from tlz.dicttoolz import valmap
 from tlz.functoolz import compose_left, curry, juxt
 
 from .calibrations import read_noise_levels
+from .manifest import read_manifest
 from .product.reader import read_product
 from .product.transformers import extract_dataset
 from .product.utils import starcall
 from .xml import read_xml
+
+try:
+    ExceptionGroup
+except NameError:
+    from exceptiongroup import ExceptionGroup
 
 
 @curry
@@ -32,6 +38,17 @@ def open_rcm(url, *, backend_kwargs=None, **dataset_kwargs):
 
     storage_options = backend_kwargs.get("storage_options", {})
     mapper = fsspec.get_mapper(url, **storage_options)
+
+    declared_files = read_manifest(mapper, "manifest.safe")
+
+    missing_files = [
+        path for path in declared_files if not mapper.fs.exists(f"{url}/{path}")
+    ]
+    if missing_files:
+        raise ExceptionGroup(
+            "not all files declared in the manifest are available",
+            [ValueError(f"{p} does not exist") for p in missing_files],
+        )
 
     tree = read_product(mapper, "metadata/product.xml")
 

--- a/safe_rcm/manifest.py
+++ b/safe_rcm/manifest.py
@@ -1,0 +1,45 @@
+from tlz import filter
+from tlz.functoolz import compose_left, curry
+from tlz.itertoolz import concat, get
+
+from .product.dicttoolz import query
+from .xml import read_xml
+
+
+def merge_location(loc):
+    locator = loc["@locator"]
+    href = loc["@href"]
+
+    return f"{locator}/{href}".lstrip("/")
+
+
+def read_manifest(mapper, path):
+    structure = {
+        "/dataObjectSection/dataObject": compose_left(
+            curry(
+                map,
+                compose_left(
+                    curry(get, "byteStream"),
+                    curry(
+                        map,
+                        compose_left(
+                            curry(get, "fileLocation"), curry(map, merge_location)
+                        ),
+                    ),
+                    concat,
+                ),
+            ),
+            concat,
+        ),
+        "/metadataSection/metadataObject": compose_left(
+            curry(
+                filter,
+                compose_left(curry(get, "@classification"), lambda x: x == "SYNTAX"),
+            ),
+            curry(map, compose_left(curry(get, "metadataReference"), merge_location)),
+        ),
+    }
+
+    manifest = read_xml(mapper, path)
+
+    return list(concat(func(query(path, manifest)) for path, func in structure.items()))


### PR DESCRIPTION
In case some files cannot be found, it is more user-friendly to raise *before* attempting (and failing) to read those files: that way, we get immediate feed-back of what's wrong.

This makes use of exception groups, a new feature in python 3.11 which for older versions has been backported by the `exceptiongroup` library (we can't make use of the `except*` syntax on `python<3.11`, though).