### PR TITLE
support nested urls and ignore `preview/*`

### DIFF
--- a/safe_rcm/api.py
+++ b/safe_rcm/api.py
@@ -57,7 +57,8 @@ def open_rcm(
     ----------
     url : str
     backend_kwargs : mapping
-    manifest_ignores : list of str, default: ["*.pdf", "*.html", "*.xslt", "*.png", "*.kml", "*.txt"]
+    manifest_ignores : list of str, default: ["*.pdf", "*.html", "*.xslt", "*.png", \
+                                              "*.kml", "*.txt", "preview/*"]
         Globs that match files from the manifest that are allowed to be missing.
     **dataset_kwargs
         Keyword arguments forwarded to `xr.open_dataset`, used to open

--- a/safe_rcm/api.py
+++ b/safe_rcm/api.py
@@ -29,14 +29,26 @@ def execute(tree, f, path):
 
 
 def ignored_file(path, ignores):
-    return any(fnmatchcase(posixpath.basename(path), ignore) for ignore in ignores)
+    ignored = [
+        fnmatchcase(path, ignore) or fnmatchcase(posixpath.basename(path), ignore)
+        for ignore in ignores
+    ]
+    return any(ignored)
 
 
 def open_rcm(
     url,
     *,
     backend_kwargs=None,
-    manifest_ignores=["*.pdf", "*.html", "*.xslt", "*.png", "*.kml", "*.txt"],
+    manifest_ignores=[
+        "*.pdf",
+        "*.html",
+        "*.xslt",
+        "*.png",
+        "*.kml",
+        "*.txt",
+        "preview/*",
+    ],
     **dataset_kwargs,
 ):
     """read SAFE files of the radarsat constellation mission (RCM)
@@ -73,7 +85,7 @@ def open_rcm(
         path
         for path in declared_files
         if not ignored_file(path, manifest_ignores)
-        and not mapper.fs.exists(f"{url}/{path}")
+        and not mapper.fs.exists(mapper._key_to_str(path))
     ]
     if missing_files:
         raise ExceptionGroup(


### PR DESCRIPTION
- [x] follow-up to #48

In order to work properly, we need to ignore *all* files in the preview directory. Also, by avoiding to manually concatenate paths we can support nested filesystems (e.g. SAFE-inside-zip)