### PR TITLE
add `fsspec` to the dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "lxml",
     "xmlschema",
     "rioxarray",
+    "fsspec",
     "exceptiongroup; python_version < '3.11'",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
It seems I forgot to add `fsspec` to the dependencies, which makes the `conda-forge` builds fail