### PR TITLE
use `fsspec`'s `dirfs` instead of relying on internal functions

### DIFF
--- a/safe_rcm/api.py
+++ b/safe_rcm/api.py
@@ -5,6 +5,7 @@ from fnmatch import fnmatchcase
 import datatree
 import fsspec
 import xarray as xr
+from fsspec.implementations.dirfs import DirFileSystem
 from tlz.dicttoolz import valmap
 from tlz.functoolz import compose_left, curry, juxt
 
@@ -74,7 +75,7 @@ def open_rcm(
 
     storage_options = backend_kwargs.get("storage_options", {})
     mapper = fsspec.get_mapper(url, **storage_options)
-    relative_fs = fsspec.implementations.dirfs.DirFileSystem(fo=url, fs=mapper.fs)
+    relative_fs = DirFileSystem(path=url, fs=mapper.fs)
 
     try:
         declared_files = read_manifest(mapper, "manifest.safe")


### PR DESCRIPTION
`fsspec` provides a filesystem implementation called `dirfs` which allows using a filesystem object with mapper keys. This allows us to avoid using `fsspec`'s internal API to construct the urls to be passed to the filesystem object's methods.

As soon as it's merged, we could also use `mapper.dirfs.open(...)` instead of creating our own, but that would require us to depend on a unreasonably new version of `fsspec`.