### PR TITLE
drop duplicate values before unstacking

### DIFF
--- a/safe_rcm/product/reader.py
+++ b/safe_rcm/product/reader.py
@@ -125,6 +125,7 @@ def read_product(mapper, product_path):
                     default_dims=["stacked"],
                 ),
                 lambda obj: obj.set_index({"stacked": ["pole", "pulse"]}),
+                lambda obj: obj.drop_duplicates("stacked", keep="last"),
                 lambda obj: obj.unstack("stacked"),
             ),
         },


### PR DESCRIPTION
- [x] closes #75

Apparently, some files contain duplicates with different values along the pulses. Until this is confirmed, we'll keep the last value (as we did before, but unintentionally).