### PR TITLE
fix version number for safe_rcm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ include = [
 ]
 
 [tool.setuptools_scm]
-fallback_version = "999"
+fallback_version = "9999"
 
 [tool.isort]
 profile = "black"

--- a/safe_rcm/__init__.py
+++ b/safe_rcm/__init__.py
@@ -1,8 +1,7 @@
-from importlib.metadata import version
-
 from .api import open_rcm  # noqa: F401
 
 try:
-    __version__ = version("safe_rcm")
-except Exception:
-    __version__ = "999"
+    from importlib import metadata
+except ImportError: # for Python<3.8
+    import importlib_metadata as metadata
+__version__ = metadata.version('xarray-safe-rcm')

--- a/safe_rcm/__init__.py
+++ b/safe_rcm/__init__.py
@@ -5,4 +5,4 @@ from .api import open_rcm  # noqa: F401
 try:
     __version__ = version("xarray-safe-rcm")
 except Exception:
-    __version__ = "999"
+    __version__ = "9999"

--- a/safe_rcm/__init__.py
+++ b/safe_rcm/__init__.py
@@ -2,6 +2,6 @@ from .api import open_rcm  # noqa: F401
 
 try:
     from importlib import metadata
-except ImportError: # for Python<3.8
+except ImportError:  # for Python<3.8
     import importlib_metadata as metadata
-__version__ = metadata.version('xarray-safe-rcm')
+__version__ = metadata.version("xarray-safe-rcm")

--- a/safe_rcm/__init__.py
+++ b/safe_rcm/__init__.py
@@ -1,7 +1,8 @@
+from importlib.metadata import version
+
 from .api import open_rcm  # noqa: F401
 
 try:
-    from importlib import metadata
-except ImportError:  # for Python<3.8
-    import importlib_metadata as metadata
-__version__ = metadata.version("xarray-safe-rcm")
+    __version__ = version("xarray-safe-rcm")
+except Exception:
+    __version__ = "999"


### PR DESCRIPTION
previously we had:

```python
In [1]: import safe_rcm
In [2]: safe_rcm.__version__
Out[2]: '999'
```

thanks to this PR we have:

```python
In [1]: import safe_rcm
In [2]: safe_rcm.__version__
Out[2]: '2024.2.1.dev6+g115d62a'
```