### PR TITLE
migrate to `xarray.DataTree`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # xarray-safe-rcm
 
-Read RCM SAFE files into `datatree` objects.
+Read RCM SAFE files into `xarray.DataTree` objects.
 
 ## Usage
 

--- a/ci/requirements/environment.yaml
+++ b/ci/requirements/environment.yaml
@@ -23,7 +23,6 @@ dependencies:
   - scipy
   # data
   - xarray
-  - xarray-datatree
   - dask
   - numpy
   - pandas

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
   "toolz",
   "numpy",
   "xarray",
-  "xarray-datatree",
   "lxml",
   "xmlschema",
   "rioxarray",

--- a/safe_rcm/api.py
+++ b/safe_rcm/api.py
@@ -2,7 +2,6 @@ import os
 import posixpath
 from fnmatch import fnmatchcase
 
-import datatree
 import fsspec
 import xarray as xr
 from fsspec.implementations.dirfs import DirFileSystem
@@ -160,7 +159,7 @@ def open_rcm(
 
     return tree.assign(
         {
-            "lookupTables": datatree.DataTree.from_dict(calibration),
-            "imagery": datatree.DataTree(imagery),
+            "lookupTables": xr.DataTree.from_dict(calibration),
+            "imagery": xr.DataTree(imagery),
         }
     )

--- a/safe_rcm/api.py
+++ b/safe_rcm/api.py
@@ -127,6 +127,7 @@ def open_rcm(
                 lambda arr: arr.set_index({"stacked": ["sarCalibrationType", "pole"]}),
                 lambda arr: arr.unstack("stacked"),
                 lambda arr: arr.rename("lookup_tables"),
+                lambda arr: arr.to_dataset(),
             ),
         },
         "/noiseLevels": {

--- a/safe_rcm/calibrations.py
+++ b/safe_rcm/calibrations.py
@@ -1,6 +1,5 @@
 import posixpath
 
-import datatree
 import numpy as np
 import xarray as xr
 from tlz.dicttoolz import itemmap, merge_with, valfilter, valmap
@@ -109,4 +108,4 @@ def read_noise_levels(mapper, root, fnames):
         merged,
     )
 
-    return datatree.DataTree.from_dict(combined)
+    return xr.DataTree.from_dict(combined)

--- a/safe_rcm/product/reader.py
+++ b/safe_rcm/product/reader.py
@@ -1,4 +1,3 @@
-import datatree
 import xarray as xr
 from tlz.dicttoolz import keyfilter, merge, merge_with, valfilter, valmap
 from tlz.functoolz import compose_left, curry, juxt
@@ -276,4 +275,4 @@ def read_product(mapper, product_path):
         lambda x: execute(**x)(decoded),
         layout,
     )
-    return datatree.DataTree.from_dict(converted)
+    return xr.DataTree.from_dict(converted)

--- a/safe_rcm/product/transformers.py
+++ b/safe_rcm/product/transformers.py
@@ -1,4 +1,3 @@
-import datatree
 import numpy as np
 import xarray as xr
 from tlz.dicttoolz import (
@@ -252,4 +251,4 @@ def extract_nested_datatree(obj, dims=None):
     datasets = merge_with(list, *obj)
     tree = valmap(curry(extract_nested_dataset)(dims=dims), datasets)
 
-    return datatree.DataTree.from_dict(tree)
+    return xr.DataTree.from_dict(tree)


### PR DESCRIPTION
> [!WARNING]
> This is untested, so a release might break production pipelines. In other words, after merging this we have to finish up the tests / CI before we can do the next release (~or someone does a manual test~ I just did, and with the last commit the library should continue to work).