### PR TITLE
reduce the frequency of `pre-commit autoupdate`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ci:
-  autoupdate_schedule: weekly
+  autoupdate_schedule: monthly
 
 # https://pre-commit.com/
 repos:


### PR DESCRIPTION
We get quite a few PRs opened by the bot for hook updates, even though the library has not seen a lot of activity. I believe it would be better to reduce the frequency to once per month (or even once per quarter).

@agrouaze, what do you think?