### PR TITLE
fix issue #123 with xmlschema==4.3.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
 
     steps:

--- a/ci/requirements/docs.yaml
+++ b/ci/requirements/docs.yaml
@@ -2,7 +2,7 @@ name: xarray-safe-rcm-docs
 channels:
   - conda-forge
 dependencies:
-  - python=3.10
+  - python=3.11
   - sphinx>=4
   - sphinx-book-theme
   - ipython

--- a/ci/requirements/environment.yaml
+++ b/ci/requirements/environment.yaml
@@ -23,7 +23,7 @@ dependencies:
   - zarr
   - scipy
   # data
-  - xarray>=2024.10.0
+  - xarray>=2025.08.0
   - dask
   - numpy
   - pandas

--- a/ci/requirements/environment.yaml
+++ b/ci/requirements/environment.yaml
@@ -23,7 +23,7 @@ dependencies:
   - zarr
   - scipy
   # data
-  - xarray
+  - xarray>=2024.10.0
   - dask
   - numpy
   - pandas

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 dependencies = [
   "toolz",
   "numpy",
-  "xarray>=2024.10.0",
+  "xarray>=2025.08.0",
   "lxml",
   "xmlschema",
   "rioxarray",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 dependencies = [
   "toolz",
   "numpy",
-  "xarray",
+  "xarray>=2024.10.0",
   "lxml",
   "xmlschema",
   "rioxarray",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xarray-safe-rcm"
-requires-python = ">= 3.10"
+requires-python = ">= 3.11"
 license = { text = "MIT" }
 description = "xarray reader for radarsat constellation mission (RCM) SAFE files"
 readme = "README.md"
@@ -31,7 +31,7 @@ include = [
 fallback_version = "9999"
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py311"
 builtins = ["ellipsis"]
 exclude = [".git", ".eggs", "build", "dist", "__pycache__"]
 line-length = 100

--- a/safe_rcm/api.py
+++ b/safe_rcm/api.py
@@ -156,7 +156,7 @@ def open_rcm(
         resolved,
     )
     dss = [ds.assign_coords(pole=coord) for coord, ds in imagery_dss.items()]
-    imagery = xr.concat(dss, dim="pole")
+    imagery = xr.concat(dss, dim="pole", compat="override", coords="minimal")
 
     return tree.assign(
         {

--- a/safe_rcm/product/reader.py
+++ b/safe_rcm/product/reader.py
@@ -10,6 +10,8 @@ from safe_rcm.product.predicates import disjunction, is_nested_array, is_scalar_
 from safe_rcm.product.utils import dictfirst, starcall
 from safe_rcm.xml import read_xml
 
+xr.set_options(use_new_combine_kwarg_defaults=True)
+
 
 @curry
 def attach_path(obj, path):
@@ -206,7 +208,12 @@ def read_product(mapper, product_path):
                     ),
                 ),
                 list,
-                curry(xr.concat, dim="burst_maps"),
+                curry(
+                    xr.concat,
+                    dim="burst_maps",
+                    combine_attrs="override",
+                    compat="equals",
+                ),
             ),
         },
         "/dopplerCentroid": {
@@ -238,7 +245,12 @@ def read_product(mapper, product_path):
                     ),
                 ),
                 list,
-                curry(xr.concat, dim="burst_maps"),
+                curry(
+                    xr.concat,
+                    dim="burst_maps",
+                    combine_attrs="override",
+                    compat="equals",
+                ),
             ),
         },
         "/dopplerRate": {
@@ -267,7 +279,12 @@ def read_product(mapper, product_path):
                     ),
                 ),
                 list,
-                curry(xr.concat, dim="burst_maps"),
+                curry(
+                    xr.concat,
+                    dim="burst_maps",
+                    combine_attrs="override",
+                    compat="equals",
+                ),
             ),
         },
     }

--- a/safe_rcm/xml.py
+++ b/safe_rcm/xml.py
@@ -1,5 +1,3 @@
-import os
-import os.path
 import posixpath
 import re
 import urllib.request
@@ -18,7 +16,8 @@ class CustomOpener(urllib.request.OpenerDirector):
     def open(self, url, data: None = None, timeout: None = None):
         # undo normalization
         # FIXME: figure out how to make xmlschema skip this step
-        path = os.path.relpath(url.removeprefix("file://"))
+        # path = os.path.relpath(url.removeprefix("file://"))
+        path = url.removeprefix("file://").lstrip("/")
 
         return self.fs.open(path)
 
@@ -27,7 +26,7 @@ def open_schema(mapper, schema_path):
     dirfs = DirFileSystem(fs=mapper.fs, path=mapper.root)
     opener = CustomOpener(dirfs)
 
-    settings = xmlschema.settings.SchemaSettings(opener=opener)
+    settings = xmlschema.settings.SchemaSettings(opener=opener, base_url="file://.")
     return xmlschema.XMLSchema.from_settings(settings=settings, source=schema_path)
 
 

--- a/safe_rcm/xml.py
+++ b/safe_rcm/xml.py
@@ -1,11 +1,35 @@
-import io
+import os
+import os.path
 import posixpath
 import re
+import urllib.request
 from collections import deque
 
 import xmlschema
+from fsspec.implementations.dirfs import DirFileSystem
 from lxml import etree
 from tlz.dicttoolz import keymap
+
+
+class CustomOpener(urllib.request.OpenerDirector):
+    def __init__(self, fs):
+        self.fs = fs
+
+    def open(self, url, data: None = None, timeout: None = None):
+        # undo normalization
+        # FIXME: figure out how to make xmlschema skip this step
+        path = os.path.relpath(url.removeprefix("file://"))
+
+        return self.fs.open(path)
+
+
+def open_schema(mapper, schema_path):
+    dirfs = DirFileSystem(fs=mapper.fs, path=mapper.root)
+    opener = CustomOpener(dirfs)
+
+    settings = xmlschema.settings.SchemaSettings(opener=opener)
+    return xmlschema.XMLSchema.from_settings(settings=settings, source=schema_path)
+
 
 include_re = re.compile(r'\s*<xsd:include schemaLocation="(?P<location>[^"/]+)"\s?/>')
 
@@ -42,31 +66,6 @@ def schema_paths(mapper, root_schema):
         unvisited.extend([p for p in normalized if p not in visited])
 
     return visited
-
-
-def open_schema(mapper, schema):
-    """fsspec-compatible way to open remote schema files
-
-    Parameters
-    ----------
-    fs : fsspec.filesystem
-        pre-instantiated fsspec filesystem instance
-    root : str
-        URL of the root directory of the schema files
-    name : str
-        File name of the schema to open.
-    glob : str, default: "*.xsd"
-        The glob used to find other schema files
-
-    Returns
-    -------
-    xmlschema.XMLSchema
-        The opened schema object
-    """
-    paths = schema_paths(mapper, schema)
-    preprocessed = [io.StringIO(remove_includes(mapper[p].decode())) for p in paths]
-
-    return xmlschema.XMLSchema(preprocessed)
 
 
 def read_xml(mapper, path):


### PR DESCRIPTION
Strategy to avoid the issue of URI and URL mal-formed with `xmlschema` is to go for a mapping of the xsd into a temporary folder on file-system.

- [x] update `open_schema()` to fix #123 
- [x] add clear docstring
- [x] test opening of a GRD RCM product with `xmlschema==4.3.1`
- [x] lint
- [x] pytest succesfull : `17 passed in 2.05s`
- [ ] ~~build `sphinx` doc successfully~~
- [x] test end2end solution with previous version of `xmlschema` -> no need of pinning.
- [x] clean warnings related to arguments of `xr.concat()` that were not clearly set.


`python end2end/open_rcm_grd_product.py `:

<details>
<summary>Click to expand the STDOUT</summary>


```python

ERROR:rasterio._filepath:FilePath is currently a read-only interface.
ERROR:rasterio._filepath:FilePath is currently a read-only interface.
INFO:rasterio._filepath:Object not found in virtual filesystem: filename=b'8360743f-daf4-4dc7-91b3-bdda6df29be7/8360743f-daf4-4dc7-91b3-bdda6df29be7.aux'
INFO:rasterio._filepath:Object not found in virtual filesystem: filename=b'8360743f-daf4-4dc7-91b3-bdda6df29be7/8360743f-daf4-4dc7-91b3-bdda6df29be7.AUX'
INFO:rasterio._filepath:Object not found in virtual filesystem: filename=b'8360743f-daf4-4dc7-91b3-bdda6df29be7/8360743f-daf4-4dc7-91b3-bdda6df29be7.aux'
INFO:rasterio._filepath:Object not found in virtual filesystem: filename=b'8360743f-daf4-4dc7-91b3-bdda6df29be7/8360743f-daf4-4dc7-91b3-bdda6df29be7.AUX'
ERROR:rasterio._filepath:FilePath is currently a read-only interface.
ERROR:rasterio._filepath:FilePath is currently a read-only interface.
INFO:rasterio._filepath:Object not found in virtual filesystem: filename=b'12545e7d-dbed-457d-be7d-f79967773cbc/12545e7d-dbed-457d-be7d-f79967773cbc.aux'
INFO:rasterio._filepath:Object not found in virtual filesystem: filename=b'12545e7d-dbed-457d-be7d-f79967773cbc/12545e7d-dbed-457d-be7d-f79967773cbc.AUX'
INFO:rasterio._filepath:Object not found in virtual filesystem: filename=b'12545e7d-dbed-457d-be7d-f79967773cbc/12545e7d-dbed-457d-be7d-f79967773cbc.aux'
INFO:rasterio._filepath:Object not found in virtual filesystem: filename=b'12545e7d-dbed-457d-be7d-f79967773cbc/12545e7d-dbed-457d-be7d-f79967773cbc.AUX'
INFO:root:<xarray.DataTree>
Group: /
│   Attributes:
│       copyright:                    RCM Data and Products (c) CSA, 2023 - All R...
│       productId:                    2737053_1
│       documentIdentifier:           RCM-SP-53-0419, Issue 2/9
│       securityClassification:       Non classifié / Unclassified
│       specialHandlingRequired:      False
│       specialHandlingInstructions:  No special handling required, use per EULA
├── Group: /sourceAttributes
│   │   Attributes:
│   │       satellite:               RCM-1
│   │       sensor:                  SAR
│   │       polarizationDataMode:    Dual Co/Cross
│   │       downlinkSegmentId:       6979970_6960859
│   │       inputDatasetFacilityId:  MASS
│   │       beamMode:                Low Noise
│   │       beamModeDefinitionId:    31
│   │       beamModeVersion:         4
│   │       beamModeMnemonic:        SCLNA
│   │       rawDataStartTime:        2023-09-10T20:37:07.917000Z
│   ├── Group: /sourceAttributes/radarParameters
│   │   │   Dimensions:                              (beams: 8, polarizations: 2,
│   │   │                                             pulses: 8, beam: 8, pole: 2)
│   │   │   Coordinates:
│   │   │     * beams                                (beams) <U4 128B 'SC-1' ... 'SC-8'
│   │   │     * polarizations                        (polarizations) <U2 16B 'VH' 'VV'
│   │   │     * pulses                               (pulses) <U6 192B '160038' ... '80036'
│   │   │     * beam                                 (beam) <U4 128B 'SC-1' ... 'SC-8'
│   │   │     * pole                                 (pole) <U2 16B 'VH' 'VV'
│   │   │   Data variables: (12/13)
│   │   │       pulsesReceivedPerDwell               (beam) int64 64B 79 92 80 ... 86 93 86
│   │   │       numberOfPulseIntervalsPerDwell       (beam) int64 64B 91 106 92 ... 107 99
│   │   │       burstDelay                           float64 8B 5.2e-05
│   │   │       rank                                 (beam) int64 64B 12 14 12 ... 13 14 13
│   │   │       settableGain                         (beam, pole) float64 128B -18.9 ... ...
│   │   │       radarCenterFrequency                 float64 8B 5.405e+09
│   │   │       ...                                   ...
│   │   │       pulseBandwidth                       (beam) float64 64B 1.6e+07 ... 8e+06
│   │   │       samplingWindowStartTimeFirstRawLine  (beam, pole) float64 128B 0.0001124 ...
│   │   │       samplingWindowStartTimeLastRawLine   (beam, pole) float64 128B 0.0001126 ...
│   │   │       numberOfSwstChanges                  (beam, pole) int64 128B 4 4 4 ... 4 4 4
│   │   │       adcSamplingRate                      (beam) float64 64B 1.792e+07 ... 1.5...
│   │   │       samplesPerEchoLine                   (beam) int64 64B 2706 2729 ... 3960
│   │   │   Attributes:
│   │   │       acquisitionType:          Low Noise
│   │   │       antennaPointing:          Right
│   │   │       zeroDopplerSteeringFlag:  ZeroDopplerSteeringOn
│   │   │       satOrientationRefFrame:   Geocentric
│   │   │       rawBitsPerSample:         3
│   │   │       steppedReceiveMode:       True
│   │   └── Group: /sourceAttributes/radarParameters/prfInformation
│   │           Dimensions:                   (beam: 8, pole: 2, burst: 18)
│   │           Coordinates:
│   │             * burst                     (burst) int64 144B 0 1 2 3 ... 1054 1057 1573 1575
│   │           Data variables:
│   │               rawLine                   (beam, pole, burst) float64 2kB 0.0 ... 1.354e+05
│   │               pulseRepetitionFrequency  (beam, pole, burst) float64 2kB 2.969e+03 ... 2...
│   ├── Group: /sourceAttributes/rawDataAttributes
│   │       Dimensions:               (pole: 2, beam: 8, histogram: 1467)
│   │       Coordinates:
│   │         * pole                  (pole) <U2 16B 'VH' 'VV'
│   │         * beam                  (beam) <U4 128B 'SC-1' 'SC-2' 'SC-3' ... 'SC-7' 'SC-8'
│   │       Dimensions without coordinates: histogram
│   │       Data variables:
│   │           numberOfMissingLines  (pole) int64 16B 0 0
│   │           bias                  (pole, beam) complex128 256B (-0.03726476430892944+...
│   │           standardDeviation     (pole, beam) complex128 256B (8.82473087310791+8.83...
│   │           gainImbalance         (pole, beam) float64 128B 0.9987 0.9996 ... 0.9992
│   │           phaseOrthogonality    (pole, beam) float64 128B -0.05198 ... -0.09932
│   │           rawDataHistogram      (histogram, pole, beam) complex128 376kB 0j 0j ... 0j
│   │       Attributes:
│   │           numberOfInputDataGaps:  0
│   │           gapSize:                100
│   └── Group: /sourceAttributes/orbitAndAttitude
│       ├── Group: /sourceAttributes/orbitAndAttitude/orbitInformation
│       │       Dimensions:    (timeStamp: 77)
│       │       Coordinates:
│       │         * timeStamp  (timeStamp) object 616B 1694378225000000000 ... 16943783010000...
│       │       Data variables:
│       │           xPosition  (timeStamp) float64 616B 4.821e+06 4.818e+06 ... 4.573e+06
│       │           yPosition  (timeStamp) float64 616B -4.363e+06 -4.362e+06 ... -4.298e+06
│       │           zPosition  (timeStamp) float64 616B 2.504e+06 2.511e+06 ... 3.026e+06
│       │           xVelocity  (timeStamp) float64 616B -3.055e+03 -3.061e+03 ... -3.465e+03
│       │           yVelocity  (timeStamp) float64 616B 649.6 655.2 ... 1.067e+03 1.072e+03
│       │           zVelocity  (timeStamp) float64 616B 6.982e+03 6.979e+03 ... 6.733e+03
│       │       Attributes:
│       │           passDirection:      Ascending
│       │           orbitDataSource:    Downlinked
│       │           withinOrbitTube:    True
│       │           orbitDataFileName:  RCM-1_2023-09-10T11-52-17_023139.PRED_ORBIT_SV
│       └── Group: /sourceAttributes/orbitAndAttitude/attitudeInformation
│               Dimensions:    (timeStamp: 154)
│               Coordinates:
│                 * timeStamp  (timeStamp) object 1kB 1694378223690000000 ... 169437830019000...
│               Data variables:
│                   yaw        (timeStamp) float64 1kB -3.507 -3.506 -3.505 ... -3.382 -3.382
│                   roll       (timeStamp) float64 1kB -33.11 -33.11 -33.11 ... -33.11 -33.11
│                   pitch      (timeStamp) float64 1kB -0.05371 -0.05369 ... -0.0517 -0.05166
│               Attributes:
│                   attitudeDataSource:      Downlink
│                   attitudeOffsetsApplied:  True
├── Group: /imageReferenceAttributes
│   │   Dimensions:              (sarCalibrationType: 3, pole: 2)
│   │   Coordinates:
│   │     * sarCalibrationType   (sarCalibrationType) <U12 144B 'Beta Nought' ... 'Si...
│   │     * pole                 (pole) <U2 16B 'VH' 'VV'
│   │   Data variables:
│   │       lookupTableFileName  (sarCalibrationType, pole) <U15 360B 'lutBeta_VH.xml...
│   │       noiseLevelFileName   (pole) <U18 144B 'noiseLevels_VH.xml' 'noiseLevels_V...
│   │   Attributes:
│   │       productFormat:            GeoTIFF
│   │       outputMediaInterleaving:  BSQ
│   │       incidenceAngleFileName:   incidenceAngles.xml
│   ├── Group: /imageReferenceAttributes/rasterAttributes
│   │       Dimensions:                  ()
│   │       Data variables:
│   │           bitsPerSample            int64 8B 16
│   │           sampledPixelSpacing      float64 8B 40.0
│   │           sampledLineSpacing       float64 8B 40.0
│   │           sampledPixelSpacingTime  float64 8B 2.669e-07
│   │           sampledLineSpacingTime   float64 8B 0.00579
│   │       Attributes:
│   │           sampleType:         Magnitude Detected
│   │           dataType:           Integer
│   │           lineTimeOrdering:   Decreasing
│   │           pixelTimeOrdering:  Increasing
│   └── Group: /imageReferenceAttributes/geographicInformation
│       ├── Group: /imageReferenceAttributes/geographicInformation/ellipsoidParameters
│       │       Dimensions:                (params: 3)
│       │       Dimensions without coordinates: params
│       │       Data variables:
│       │           semiMajorAxis          float64 8B 6.378e+06
│       │           semiMinorAxis          float64 8B 6.357e+06
│       │           datumShiftParameters   (params) float64 24B 0.0 0.0 0.0
│       │           geodeticTerrainHeight  float64 8B 0.7563
│       │       Attributes:
│       │           ellipsoidName:  WGS 1984
│       ├── Group: /imageReferenceAttributes/geographicInformation/geolocationGrid
│       │       Dimensions:             (line: 17, pixel: 12)
│       │       Coordinates:
│       │         * line                (line) float64 136B 0.0 787.2 ... 1.181e+04 1.26e+04
│       │         * pixel               (pixel) float64 96B 0.0 813.6 ... 8.136e+03 8.95e+03
│       │       Data variables:
│       │           latitude            (line, pixel) float64 2kB 26.21 26.27 ... 22.25 22.3
│       │           longitude           (line, pixel) float64 2kB -41.44 -41.12 ... -37.04
│       │           height              (line, pixel) float64 2kB 0.7563 0.7563 ... 0.7563
│       └── Group: /imageReferenceAttributes/geographicInformation/rationalFunctions
│               Dimensions:                       (coefficients: 20)
│               Dimensions without coordinates: coefficients
│               Data variables:
│                   biasError                     float64 8B 0.5
│                   randomError                   float64 8B 0.5
│                   latitudeOffset                float64 8B 24.25
│                   longitudeOffset               float64 8B -39.25
│                   heightOffset                  float64 8B 0.0
│                   lineNumeratorCoefficients     (coefficients) float64 160B 0.003049 ... 0.0
│                   lineDenominatorCoefficients   (coefficients) float64 160B 1.0 ... 0.0
│                   pixelNumeratorCoefficients    (coefficients) float64 160B -0.02144 ... 2....
│                   pixelDenominatorCoefficients  (coefficients) float64 160B 1.0 ... 1.964e-06
│               Attributes:
│                   lineFitQuality:   0.00048058903248104
│                   pixelFitQuality:  0.4051047447254232
│                   lineOffset:       6298
│                   pixelOffset:      4474
│                   lineScale:        6298
│                   pixelScale:       4476
│                   latitudeScale:    2.5497
│                   longitudeScale:   2.2087
│                   heightScale:      601.0
├── Group: /sceneAttributes
│       Dimensions:             (pole: 2)
│       Coordinates:
│         * pole                (pole) <U2 16B 'VV' 'VH'
│       Data variables:
│           ipdf                (pole) <U27 216B '../imagery/2737053_1_VV.tif' '../im...
│           incAngNearRng       float64 8B 18.76
│           incAngFarRng        float64 8B 46.16
│           slantRangeNearEdge  float64 8B 6.227e+05
│           slantRangeFarEdge   float64 8B 8.194e+05
│           mean                (pole) float64 16B 2.1e+03 225.6
│           sigma               (pole) float64 16B 1.452e+03 106.3
│       Attributes:
│           pixelOffset:     0
│           lineOffset:      0
│           numLines:        12597
│           samplesPerLine:  8951
├── Group: /grdBurstMap
│       Dimensions:           (burst_maps: 1, burst: 2069, beam: 8)
│       Coordinates:
│         * burst             (burst) int64 17kB 0 1 2 3 4 ... 2064 2065 2066 2067 2068
│         * beam              (beam) <U4 128B 'SC-1' 'SC-2' 'SC-3' ... 'SC-7' 'SC-8'
│       Dimensions without coordinates: burst_maps
│       Data variables:
│           topLeftLine       (burst_maps, burst, beam) float64 132kB 1.245e+04 ... nan
│           topLeftPixel      (burst_maps, burst, beam) float64 132kB 0.0 nan ... nan
│           bottomRightLine   (burst_maps, burst, beam) float64 132kB 1.25e+04 ... nan
│           bottomRightPixel  (burst_maps, burst, beam) float64 132kB 1.144e+03 ... nan
│       Attributes:
│           numberOfEntries:  2069
│           numberOfBeams:    8
├── Group: /dopplerCentroid
│       Dimensions:                        (burst_maps: 1, burst: 2069, coefficients: 4)
│       Coordinates:
│         * burst                          (burst) int64 17kB 0 1 2 3 ... 2066 2067 2068
│       Dimensions without coordinates: burst_maps, coefficients
│       Data variables:
│           timeOfDopplerCentroidEstimate  (burst_maps, burst) <U27 223kB '2023-09-10...
│           dopplerAmbiguity               (burst_maps, burst) int64 17kB 0 0 0 ... 0 0
│           dopplerCentroidReferenceTime   (burst_maps, burst) float64 17kB 0.004169 ...
│           dopplerCentroidCoefficients    (burst_maps, burst, coefficients) float64 66kB ...
│           dopplerCentroidConfidence      (burst_maps, burst) float64 17kB 0.9281 .....
│       Attributes:
│           numberOfEstimates:  2069
├── Group: /dopplerRate
│       Dimensions:                    (burst_maps: 1, burst: 2069, coefficients: 5)
│       Coordinates:
│         * burst                      (burst) int64 17kB 0 1 2 3 ... 2066 2067 2068
│       Dimensions without coordinates: burst_maps, coefficients
│       Data variables:
│           timeOfDopplerRateEstimate  (burst_maps, burst) <U27 223kB '2023-09-10T20:...
│           dopplerRateReferenceTime   (burst_maps, burst) float64 17kB 0.004154 ... ...
│           dopplerRateCoefficients    (burst_maps, burst, coefficients) float64 83kB ...
│       Attributes:
│           numberOfEstimates:  2069
├── Group: /imageGenerationParameters
│   ├── Group: /imageGenerationParameters/generalProcessingInformation
│   │       Attributes:
│   │           productType:         GRD
│   │           processingFacility:  SHUB
│   │           processingTime:      2023-09-10T20:49:52.000000Z
│   │           softwareVersion:     RCM PGS 7.06
│   │           processingMode:      Standard
│   │           processingPriority:  High
│   ├── Group: /imageGenerationParameters/sarProcessingInformation
│   │       Dimensions:                               (pole: 2, beam: 8)
│   │       Coordinates:
│   │         * pole                                  (pole) <U2 16B 'VV' 'VH'
│   │         * beam                                  (beam) <U4 128B 'SC-1' ... 'SC-8'
│   │       Data variables:
│   │           atmosphericPropagationDelay           float64 8B 0.0
│   │           numberOfLinesProcessed                (pole) int64 16B 177923 177923
│   │           rangeLookBandwidth                    float64 8B 5.161e+06
│   │           totalProcessedRangeBandwidth          float64 8B 1.6e+07
│   │           perBeamNumberOfRangeLooks             (beam) int64 64B 4 4 4 4 4 4 4 4
│   │           perBeamRangeLookBandwidths            (beam) float64 64B 5.161e+06 ... 2....
│   │           perBeamTotalProcessedRangeBandwidths  (beam) float64 64B 5.161e+06 ... 2....
│   │           azimuthLookBandwidth                  (beam) float64 64B 81.22 ... 81.42
│   │           totalProcessedAzimuthBandwidth        (beam) float64 64B 81.22 ... 81.42
│   │           satelliteHeight                       float64 8B 5.924e+05
│   │       Attributes: (12/19)
│   │           lutApplied:                      Constant-beta
│   │           perPolarizationScaling:          True
│   │           atmosphericCorrection:           False
│   │           elevationPatternCorrection:      True
│   │           rangeSpreadingLossCorrection:    True
│   │           pulseDependentGainCorrection:    True
│   │           ...                              ...
│   │           radiometricSmoothingPerformed:   True
│   │           zeroDopplerTimeFirstLine:        2023-09-10T20:38:20.908422Z
│   │           zeroDopplerTimeLastLine:         2023-09-10T20:37:07.982007Z
│   │           numberOfRangeLooks:              4
│   │           perBeamNumberOfRangeLooksUsed:   True
│   │           numberOfAzimuthLooks:            2
│   ├── Group: /imageGenerationParameters/chirps
│   │       Dimensions:                  (pole: 2, pulse: 7, coefficients: 4)
│   │       Coordinates:
│   │         * pole                     (pole) <U2 16B 'VH' 'VV'
│   │         * pulse                    (pulse) <U2 56B '31' '36' '40' '41' '42' '43' '44'
│   │       Dimensions without coordinates: coefficients
│   │       Data variables:
│   │           chirpPower               (pole, pulse) float64 112B 122.4 120.3 ... 121.2
│   │           amplitudeCoefficients    (coefficients, pole, pulse) float64 448B 1.0 ......
│   │           phaseCoefficients        (coefficients, pole, pulse) float64 448B 0.8299 ...
│   │           replicaQualityValid      (pole, pulse) bool 14B True True True ... True True
│   │           crossCorrelationWidth    (pole, pulse) float64 112B 0.9774 0.9948 ... 1.667
│   │           sideLobeLevel            (pole, pulse) float64 112B -13.08 -13.16 ... -13.16
│   │           integratedSideLobeRatio  (pole, pulse) float64 112B -11.16 -11.19 ... -11.16
│   │           crossCorrelationPeakLoc  (pole, pulse) float64 112B 19.64 17.27 ... 15.23
│   └── Group: /imageGenerationParameters/slantRangeToGroundRange
│           Dimensions:                           (zeroDopplerAzimuthTime: 366,
│                                                  coefficients: 13)
│           Coordinates:
│             * zeroDopplerAzimuthTime            (zeroDopplerAzimuthTime) <U27 40kB '202...
│           Dimensions without coordinates: coefficients
│           Data variables:
│               slantRangeTimeToFirstRangeSample  (zeroDopplerAzimuthTime) float64 3kB 0....
│               groundRangeOrigin                 (zeroDopplerAzimuthTime) float64 3kB 0....
│               groundToSlantRangeCoefficients    (zeroDopplerAzimuthTime, coefficients) float64 38kB ...
├── Group: /lookupTables
│   ├── Group: /lookupTables/incidenceAngles
│   │       Dimensions:  (coefficients: 747)
│   │       Dimensions without coordinates: coefficients
│   │       Data variables:
│   │           angles   (coefficients) float64 6kB 18.76 18.81 18.86 ... 46.11 46.14 46.17
│   │       Attributes:
│   │           pixelFirstAnglesValue:  0
│   │           stepSize:               12
│   │           numberOfValues:         747
│   ├── Group: /lookupTables/lookupTables
│   │       Dimensions:             (sarCalibrationType: 3, pole: 2, coefficients: 747)
│   │       Coordinates:
│   │         * sarCalibrationType  (sarCalibrationType) <U12 144B 'Beta Nought' ... 'Sig...
│   │         * pole                (pole) <U2 16B 'VH' 'VV'
│   │       Dimensions without coordinates: coefficients
│   │       Data variables:
│   │           lookup_tables       (coefficients, sarCalibrationType, pole) float64 36kB ...
│   └── Group: /lookupTables/noiseLevels
│       ├── Group: /lookupTables/noiseLevels/referenceNoiseLevel
│       │       Dimensions:               (pole: 2, sarCalibrationType: 3, coefficients: 747)
│       │       Coordinates:
│       │         * sarCalibrationType    (sarCalibrationType) <U12 144B 'Beta Nought' ... 'S...
│       │           pixelFirstNoiseValue  int64 8B 0
│       │           stepSize              int64 8B 12
│       │         * pole                  (pole) <U2 16B 'VH' 'VV'
│       │       Dimensions without coordinates: coefficients
│       │       Data variables:
│       │           noiseLevelValues      (pole, sarCalibrationType, coefficients) float64 36kB ...
│       │       Attributes:
│       │           numberOfValues:  747
│       ├── Group: /lookupTables/noiseLevels/perBeamReferenceNoiseLevel
│       │       Dimensions:               (pole: 2, beam: 8, sarCalibrationType: 3,
│       │                                  coefficients: 609)
│       │       Coordinates:
│       │         * beam                  (beam) object 64B 'SC-1' 'SC-2' ... 'SC-7' 'SC-8'
│       │         * sarCalibrationType    (sarCalibrationType) object 24B 'Beta Nought' ... '...
│       │           pixelFirstNoiseValue  (beam) int64 64B 0 1109 2213 3317 4422 5528 6631 7735
│       │           stepSize              int64 8B 2
│       │         * pole                  (pole) <U2 16B 'VH' 'VV'
│       │       Dimensions without coordinates: coefficients
│       │       Data variables:
│       │           noiseLevelValues      (pole, beam, sarCalibrationType, coefficients) float64 234kB ...
│       └── Group: /lookupTables/noiseLevels/azimuthNoiseLevelScaling
│               Dimensions:                  (pole: 2, beam: 8, coefficients: 405)
│               Coordinates:
│                 * beam                     (beam) object 64B 'SC-1' 'SC-2' ... 'SC-7' 'SC-8'
│                   stepSize                 int64 8B -1
│                 * pole                     (pole) <U2 16B 'VH' 'VV'
│               Dimensions without coordinates: coefficients
│               Data variables:
│                   noiseLevelScalingValues  (pole, beam, coefficients) float64 52kB 0.0 ... 0.0
│               Attributes:
│                   numberOfNoiseLevelScalingValues:  405
└── Group: /imagery
        Dimensions:      (pole: 2, band: 1, y: 12597, x: 8951)
        Coordinates:
          * band         (band) int64 8B 1
            spatial_ref  int64 8B 0
          * pole         (pole) <U2 16B 'VV' 'VH'
        Dimensions without coordinates: y, x
        Data variables:
            band_data    (pole, band, y, x) float32 902MB 0.0 0.0 0.0 ... 0.0 0.0 0.0
```
</details>

I don't like much the first warnings but they seem harmless.
Final datatree does contain the polarizations and the beams attributes.